### PR TITLE
[WIP] 2D map generator tool: wallmap

### DIFF
--- a/src/tools/wallmap/converter.go
+++ b/src/tools/wallmap/converter.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"image"
+	"image/color"
+)
+
+// Converter converts the original image with different color model.
+//
+// It implements image.Image as it contains the original image
+type Converter struct {
+	Img image.Image
+	Mod color.Model
+}
+
+// ColorModel returns the color model
+func (c *Converter) ColorModel() color.Model {
+	// return the new color model...
+	return c.Mod
+}
+
+// Bounds returns the original image bounds
+func (c *Converter) Bounds() image.Rectangle {
+	// ... but the original bounds
+	return c.Img.Bounds()
+}
+
+// At forwards the call to the original image and then asks the color model to
+// convert it.
+func (c *Converter) At(x, y int) color.Color {
+	return c.Mod.Convert(c.Img.At(x, y))
+}

--- a/src/tools/wallmap/goget.sh
+++ b/src/tools/wallmap/goget.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+go get -u github.com/fogleman/gg
+go get -u golang.org/x/image/bmp

--- a/src/tools/wallmap/objloader.go
+++ b/src/tools/wallmap/objloader.go
@@ -269,5 +269,9 @@ func ReadObjFile(path string, dbg bool) (*ObjFile, error) {
 
 		lineno++
 	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error parsing file: %v", err)
+	}
+
 	return &obj, nil
 }

--- a/src/tools/wallmap/objloader.go
+++ b/src/tools/wallmap/objloader.go
@@ -83,12 +83,12 @@ func NewAABB() AABB {
 
 func (bb *AABB) extend(other AABB) {
 	// update the min and max for each coord
-	SetMin(&bb.MinX, other.MinX)
-	SetMin(&bb.MinY, other.MinY)
-	SetMin(&bb.MinZ, other.MinZ)
-	SetMax(&bb.MaxX, other.MaxX)
-	SetMax(&bb.MaxY, other.MaxY)
-	SetMax(&bb.MaxZ, other.MaxZ)
+	updateMin(&bb.MinX, other.MinX)
+	updateMin(&bb.MinY, other.MinY)
+	updateMin(&bb.MinZ, other.MinZ)
+	updateMax(&bb.MaxX, other.MaxX)
+	updateMax(&bb.MaxY, other.MaxY)
+	updateMax(&bb.MaxZ, other.MaxZ)
 }
 
 func (bb *AABB) Scale(f float64) {
@@ -135,15 +135,15 @@ type ObjFile struct {
 	dbg       bool
 }
 
-// SetMin checks if a > b, then a will be set to the value of b.
-func SetMin(a *float64, b float64) {
+// updateMin checks if a > b, then a will be set to the value of b.
+func updateMin(a *float64, b float64) {
 	if b < *a {
 		*a = b
 	}
 }
 
-// SetMax checks if a < b, then a will be set to the value of b.
-func SetMax(a *float64, b float64) {
+// updateMax checks if a < b, then a will be set to the value of b.
+func updateMax(a *float64, b float64) {
 	if *a < b {
 		*a = b
 	}

--- a/src/tools/wallmap/objloader.go
+++ b/src/tools/wallmap/objloader.go
@@ -11,6 +11,18 @@ import (
 
 type Vertex [4]float64
 
+func NewVertex2D(x, y float64) Vertex {
+	return Vertex{x, y, 0, 0}
+}
+
+func NewVertex3D(x, y, z float64) Vertex {
+	return Vertex{x, y, z, 0}
+}
+
+func NewVertex4D(x, y, z, w float64) Vertex {
+	return Vertex{x, y, z, w}
+}
+
 func (v *Vertex) Scale(f float64) {
 	for i := range v {
 		v[i] *= f

--- a/src/tools/wallmap/objloader.go
+++ b/src/tools/wallmap/objloader.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math"
+	"os"
+	"strings"
+)
+
+type Point2 struct {
+	X, Y float64
+}
+
+func (p *Point2) Scale(f float64) {
+	p.X = p.X * f
+	p.Y = p.Y * f
+}
+
+func Point2From3(p Point3) Point2 {
+	return Point2{p.X, p.Y}
+}
+
+type Point3 struct {
+	X, Y, Z float64
+}
+
+func (p *Point3) Set(s []string) error {
+	if _, err := fmt.Sscanf(s[0], "%f", &p.X); err != nil {
+		return fmt.Errorf("invalid syntax \"%s\"", s)
+	}
+	if _, err := fmt.Sscanf(s[1], "%f", &p.Z); err != nil {
+		return fmt.Errorf("invalid syntax \"%s\"", s)
+	}
+	if _, err := fmt.Sscanf(s[2], "%f", &p.Y); err != nil {
+		return fmt.Errorf("invalid syntax \"%s\"", s)
+	}
+	return nil
+}
+
+type Triangle struct {
+	P1, P2, P3 Point2
+}
+
+func (t *Triangle) Scale(f float64) {
+	t.P1.Scale(f)
+	t.P2.Scale(f)
+	t.P3.Scale(f)
+}
+
+func (t Triangle) MinX() float64 {
+	return math.Min(t.P1.X, math.Min(t.P2.X, t.P3.X))
+}
+
+func (t Triangle) MinY() float64 {
+	return math.Min(t.P1.Y, math.Min(t.P2.Y, t.P3.Y))
+}
+
+func (t Triangle) MaxX() float64 {
+	return math.Max(t.P1.X, math.Max(t.P2.X, t.P3.X))
+}
+
+func (t Triangle) MaxY() float64 {
+	return math.Max(t.P1.Y, math.Max(t.P2.Y, t.P3.Y))
+}
+
+func (t Triangle) isDegenerate() bool {
+	area := ((t.P2.X-t.P1.X)*(t.P3.Y-t.P1.Y) -
+		(t.P3.X-t.P1.X)*(t.P2.Y-t.P1.Y))
+	// TODO: also check area with an epsilon?
+	return area == 0.0
+}
+
+type ObjFile struct {
+	Vertices               []Point2
+	Triangles              []Triangle
+	MinX, MinY, MaxX, MaxY float64
+	dbg                    bool
+}
+
+// SetMin checks if a > b, then a will be set to the value of b.
+func SetMin(a *float64, b float64) {
+	if b < *a {
+		*a = b
+	}
+}
+
+// SetMax checks if a < b, then a will be set to the value of b.
+func SetMax(a *float64, b float64) {
+	if *a < b {
+		*a = b
+	}
+}
+
+func (of *ObjFile) parseVertex(lineno int, kw string, data []string) error {
+	p3 := Point3{}
+	err := p3.Set(data)
+	if err != nil {
+		return err
+	}
+	// discard the Z coordinate
+	of.Vertices = append(of.Vertices, Point2From3(p3))
+	return nil
+}
+
+func (of *ObjFile) parseFace(lineno int, kw string, data []string) error {
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println("Error in parseFace", r)
+			fmt.Printf("lineno: %+v | kw: +%v | data : %+v\n", lineno, kw, data)
+			fmt.Println("len(of.Vertices): ", len(of.Vertices))
+			os.Exit(1)
+		}
+	}()
+
+	if len(data) != 3 {
+		return fmt.Errorf("line: %d, only triangular faces are supported", lineno)
+	}
+
+	// vertices indices
+	vi := [3]int{}
+	for i, s := range data {
+		// we are only interested in the vertex index
+		sidx := strings.Split(s, "/")[0]
+		if _, err := fmt.Sscanf(sidx, "%d", &(vi[i])); err != nil {
+			return fmt.Errorf("invalid syntax \"%s\"", s)
+		}
+	}
+
+	t := Triangle{
+		P1: of.Vertices[vi[0]-1],
+		P2: of.Vertices[vi[1]-1],
+		P3: of.Vertices[vi[2]-1],
+	}
+
+	// track min/max bounds
+	SetMin(&of.MinX, t.MinX())
+	SetMin(&of.MinY, t.MinY())
+	SetMax(&of.MaxX, t.MaxX())
+	SetMax(&of.MaxY, t.MaxY())
+
+	// discard degenerate triangles
+	if t.isDegenerate() {
+		if of.dbg {
+			fmt.Println("found degenerate triangle: ", t)
+		}
+		return nil
+	}
+
+	of.Triangles = append(of.Triangles, t)
+	return nil
+}
+
+func ReadObjFile(path string, dbg bool) (*ObjFile, error) {
+	in, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer in.Close()
+
+	lineno := 0
+
+	// init min/max values
+	obj := ObjFile{
+		MinX: math.MaxFloat64,
+		MinY: math.MaxFloat64,
+		MaxX: -math.MaxFloat64,
+		MaxY: -math.MaxFloat64,
+		dbg:  dbg,
+	}
+
+	scanner := bufio.NewScanner(in)
+	for scanner.Scan() {
+		line := strings.Split(scanner.Text(), " ")
+		kw, vals := line[0], line[1:]
+		switch kw {
+		case "v":
+			err := obj.parseVertex(lineno, kw, vals)
+			if err != nil {
+				return nil, fmt.Errorf("error parsing vertex: %v", err)
+			}
+		case "f":
+			err := obj.parseFace(lineno, kw, vals)
+			if err != nil {
+				return nil, fmt.Errorf("error parsing face: %v", err)
+			}
+		default:
+			// ignore everything else
+		}
+
+		lineno++
+	}
+	return &obj, nil
+}

--- a/src/tools/wallmap/objloader.go
+++ b/src/tools/wallmap/objloader.go
@@ -78,11 +78,24 @@ func (t Triangle) MaxY() float64 {
 }
 
 func (t Triangle) isDegenerate() bool {
-	area := ((t.P2.X()-t.P1.X())*(t.P3.Y()-t.P1.Y()) -
-		(t.P3.X()-t.P1.X())*(t.P2.Y()-t.P1.Y()))
+	// find the determinant of the 3x3 matrix in which the triangle coords can
+	// be represented, it's 0 or close to 0.0, the triangle area is null and we
+	// consider the triangle as degenerate
+	det := (t.P1.X() * t.P2.Y() * t.P3.Z()) +
+		(t.P1.Y() * t.P2.Z() * t.P3.X()) +
+		(t.P1.Z() * t.P2.X() * t.P3.Y()) -
+		(t.P1.Z() * t.P2.Y() * t.P3.X()) -
+		(t.P1.Y() * t.P2.X() * t.P3.Z()) -
+		(t.P1.X() * t.P2.Z() * t.P3.Y())
+
 	// TODO: also check area with an epsilon?
-	return area == 0.0
+	return det == 0.0
 }
+
+type ObjFile struct {
+	Vertices 	// TODO: also check area with an epsilon?
+AABB
+	dbg       boo}
 
 type ObjFile struct {
 	Vertices               []Vertex

--- a/src/tools/wallmap/objloader.go
+++ b/src/tools/wallmap/objloader.go
@@ -9,42 +9,53 @@ import (
 	"strings"
 )
 
+// Vertex represents a 4D vertex.
 type Vertex [4]float64
 
+// NewVertex2D returns a 2D Vertex.
 func NewVertex2D(x, y float64) Vertex {
 	return Vertex{x, y, 0, 0}
 }
 
+// NewVertex3D returns a 3D Vertex.
 func NewVertex3D(x, y, z float64) Vertex {
 	return Vertex{x, y, z, 0}
 }
 
+// NewVertex4D returns a 4D Vertex.
 func NewVertex4D(x, y, z, w float64) Vertex {
 	return Vertex{x, y, z, w}
 }
 
+// Scale scales every coordinates by a given scale factor.
 func (v *Vertex) Scale(f float64) {
 	for i := range v {
 		v[i] *= f
 	}
 }
 
+// X returns the vertex X component.
 func (v Vertex) X() float64 {
 	return v[0]
 }
 
+// Y returns the vertex Y component.
 func (v Vertex) Y() float64 {
 	return v[1]
 }
 
+// Z returns the vertex Z component.
 func (v Vertex) Z() float64 {
 	return v[2]
 }
 
+// W returns the vertex W component.
 func (v Vertex) W() float64 {
 	return v[3]
 }
 
+// Set initializes a vertex from a string array where every string represents a
+// vertex component.
 func (v *Vertex) Set(s []string) error {
 	var (
 		err error

--- a/src/tools/wallmap/objloader.go
+++ b/src/tools/wallmap/objloader.go
@@ -232,7 +232,7 @@ func ReadObjFile(path string, dbg bool) (*ObjFile, error) {
 	}
 	defer in.Close()
 
-	lineno := 0
+	lineno := 1
 
 	// init min/max values
 	obj := ObjFile{

--- a/src/tools/wallmap/objloader.go
+++ b/src/tools/wallmap/objloader.go
@@ -197,13 +197,18 @@ func (of *ObjFile) parseFace(lineno int, kw string, data []string) error {
 		return fmt.Errorf("line: %d, only triangular faces are supported", lineno)
 	}
 
+	var (
+		vi  [3]int
+		err error
+	)
+
 	// vertices indices
-	vi := [3]int{}
 	for i, s := range data {
 		// we are only interested in the vertex index
 		sidx := strings.Split(s, "/")[0]
-		if _, err := fmt.Sscanf(sidx, "%d", &(vi[i])); err != nil {
-			return fmt.Errorf("invalid syntax \"%s\"", s)
+		vi[i], err = strconv.Atoi(sidx)
+		if err != nil {
+			return fmt.Errorf("invalid vertex coordinate value \"%s\"", s)
 		}
 	}
 

--- a/src/tools/wallmap/objloader.go
+++ b/src/tools/wallmap/objloader.go
@@ -136,8 +136,7 @@ func (t Triangle) isDegenerate() bool {
 		(t.P1.Y() * t.P2.X() * t.P3.Z()) -
 		(t.P1.X() * t.P2.Z() * t.P3.Y())
 
-	// TODO: also check area with an epsilon?
-	return det == 0.0
+	return math.Abs(det) < 1e-5
 }
 
 type ObjFile struct {

--- a/src/tools/wallmap/objloader.go
+++ b/src/tools/wallmap/objloader.go
@@ -61,6 +61,10 @@ func (v *Vertex) Set(s []string) error {
 		err error
 	)
 
+	if len(s) > 4 {
+		return fmt.Errorf("Vertex.Set: invalid string length")
+	}
+
 	for i := range s {
 		if v[i], err = strconv.ParseFloat(s[i], 64); err != nil {
 			return fmt.Errorf("invalid syntax \"%v\": %s", s[i], err)

--- a/src/tools/wallmap/objloader.go
+++ b/src/tools/wallmap/objloader.go
@@ -173,20 +173,6 @@ func (of ObjFile) AABB() AABB {
 	return of.aabb
 }
 
-// updateMin checks if a > b, then a will be set to the value of b.
-func updateMin(a *float64, b float64) {
-	if b < *a {
-		*a = b
-	}
-}
-
-// updateMax checks if a < b, then a will be set to the value of b.
-func updateMax(a *float64, b float64) {
-	if *a < b {
-		*a = b
-	}
-}
-
 func (of *ObjFile) parseVertex(lineno int, kw string, data []string) error {
 	v := Vertex{}
 	err := v.Set(data)
@@ -289,4 +275,18 @@ func ReadObjFile(path string, dbg bool) (*ObjFile, error) {
 	}
 
 	return &obj, nil
+}
+
+// updateMin checks if a > b, then a will be set to the value of b.
+func updateMin(a *float64, b float64) {
+	if b < *a {
+		*a = b
+	}
+}
+
+// updateMax checks if a < b, then a will be set to the value of b.
+func updateMax(a *float64, b float64) {
+	if *a < b {
+		*a = b
+	}
 }

--- a/src/tools/wallmap/objloader.go
+++ b/src/tools/wallmap/objloader.go
@@ -242,15 +242,19 @@ func ReadObjFile(path string, dbg bool) (*ObjFile, error) {
 
 	scanner := bufio.NewScanner(in)
 	for scanner.Scan() {
+
 		line := strings.Split(scanner.Text(), " ")
 		kw, vals := line[0], line[1:]
+
 		switch kw {
+
 		case "v":
 			err := obj.parseVertex(kw, vals)
 			if err != nil {
 				return nil, fmt.Errorf("error parsing vertex at line %d,\"%v\": %s", lineno, vals, err)
 
 			}
+
 		case "f":
 			err := obj.parseFace(kw, vals)
 			switch err {
@@ -263,6 +267,7 @@ func ReadObjFile(path string, dbg bool) (*ObjFile, error) {
 			default:
 				return nil, fmt.Errorf("error parsing face at line %d,\"%v\": %s", lineno, vals, err)
 			}
+
 		default:
 			// ignore everything else
 		}

--- a/src/tools/wallmap/objloader.go
+++ b/src/tools/wallmap/objloader.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -62,7 +63,7 @@ func (v *Vertex) Set(s []string) error {
 	)
 
 	if len(s) > 4 {
-		return fmt.Errorf("Vertex.Set: invalid string length")
+		return errors.New("Vertex.Set: invalid string length")
 	}
 
 	for i := range s {

--- a/src/tools/wallmap/objloader.go
+++ b/src/tools/wallmap/objloader.go
@@ -129,10 +129,22 @@ func (t Triangle) isDegenerate() bool {
 }
 
 type ObjFile struct {
-	Vertices  []Vertex
-	Triangles []Triangle
-	AABB      AABB
+	vertices  []Vertex
+	triangles []Triangle
+	aabb      AABB
 	dbg       bool
+}
+
+func (of ObjFile) Vertices() []Vertex {
+	return of.vertices
+}
+
+func (of ObjFile) Triangles() []Triangle {
+	return of.triangles
+}
+
+func (of ObjFile) AABB() AABB {
+	return of.aabb
 }
 
 // updateMin checks if a > b, then a will be set to the value of b.
@@ -156,7 +168,7 @@ func (of *ObjFile) parseVertex(lineno int, kw string, data []string) error {
 		return err
 	}
 	// discard the Z coordinate
-	of.Vertices = append(of.Vertices, v)
+	of.vertices = append(of.vertices, v)
 	return nil
 }
 
@@ -165,7 +177,7 @@ func (of *ObjFile) parseFace(lineno int, kw string, data []string) error {
 		if r := recover(); r != nil {
 			fmt.Println("Error in parseFace", r)
 			fmt.Printf("lineno: %+v | kw: +%v | data : %+v\n", lineno, kw, data)
-			fmt.Println("len(of.Vertices): ", len(of.Vertices))
+			fmt.Println("len(of.vertices): ", len(of.vertices))
 			os.Exit(1)
 		}
 	}()
@@ -185,13 +197,13 @@ func (of *ObjFile) parseFace(lineno int, kw string, data []string) error {
 	}
 
 	t := Triangle{
-		P1: of.Vertices[vi[0]-1],
-		P2: of.Vertices[vi[1]-1],
-		P3: of.Vertices[vi[2]-1],
+		P1: of.vertices[vi[0]-1],
+		P2: of.vertices[vi[1]-1],
+		P3: of.vertices[vi[2]-1],
 	}
 
 	// extend the mesh bounding box with the triangle
-	of.AABB.extend(t.AABB())
+	of.aabb.extend(t.AABB())
 
 	// discard degenerate triangles
 	if t.isDegenerate() {
@@ -201,7 +213,7 @@ func (of *ObjFile) parseFace(lineno int, kw string, data []string) error {
 		return nil
 	}
 
-	of.Triangles = append(of.Triangles, t)
+	of.triangles = append(of.triangles, t)
 	return nil
 }
 
@@ -216,7 +228,7 @@ func ReadObjFile(path string, dbg bool) (*ObjFile, error) {
 
 	// init min/max values
 	obj := ObjFile{
-		AABB: NewAABB(),
+		aabb: NewAABB(),
 		dbg:  dbg,
 	}
 

--- a/src/tools/wallmap/objloader.go
+++ b/src/tools/wallmap/objloader.go
@@ -186,14 +186,6 @@ func (of *ObjFile) parseVertex(kw string, data []string) error {
 }
 
 func (of *ObjFile) parseFace(kw string, data []string) error {
-	defer func() {
-		if r := recover(); r != nil {
-			fmt.Println("Error in parseFace", r)
-			fmt.Println("len(of.vertices): ", len(of.vertices))
-			os.Exit(1)
-		}
-	}()
-
 	if len(data) != 3 {
 		return errors.New("only triangular faces are supported")
 	}

--- a/src/tools/wallmap/objloader.go
+++ b/src/tools/wallmap/objloader.go
@@ -17,6 +17,22 @@ func (v *Vertex) Scale(f float64) {
 	}
 }
 
+func (v Vertex) X() float64 {
+	return v[0]
+}
+
+func (v Vertex) Y() float64 {
+	return v[1]
+}
+
+func (v Vertex) Z() float64 {
+	return v[2]
+}
+
+func (v Vertex) W() float64 {
+	return v[3]
+}
+
 func (v *Vertex) Set(s []string) error {
 	var (
 		err error
@@ -46,24 +62,24 @@ func (t *Triangle) Scale(f float64) {
 }
 
 func (t Triangle) MinX() float64 {
-	return math.Min(t.P1.X, math.Min(t.P2.X, t.P3.X))
+	return math.Min(t.P1.X(), math.Min(t.P2.X(), t.P3.X()))
 }
 
 func (t Triangle) MinY() float64 {
-	return math.Min(t.P1.Y, math.Min(t.P2.Y, t.P3.Y))
+	return math.Min(t.P1.Y(), math.Min(t.P2.Y(), t.P3.Y()))
 }
 
 func (t Triangle) MaxX() float64 {
-	return math.Max(t.P1.X, math.Max(t.P2.X, t.P3.X))
+	return math.Max(t.P1.X(), math.Max(t.P2.X(), t.P3.X()))
 }
 
 func (t Triangle) MaxY() float64 {
-	return math.Max(t.P1.Y, math.Max(t.P2.Y, t.P3.Y))
+	return math.Max(t.P1.Y(), math.Max(t.P2.Y(), t.P3.Y()))
 }
 
 func (t Triangle) isDegenerate() bool {
-	area := ((t.P2.X-t.P1.X)*(t.P3.Y-t.P1.Y) -
-		(t.P3.X-t.P1.X)*(t.P2.Y-t.P1.Y))
+	area := ((t.P2.X()-t.P1.X())*(t.P3.Y()-t.P1.Y()) -
+		(t.P3.X()-t.P1.X())*(t.P2.Y()-t.P1.Y()))
 	// TODO: also check area with an epsilon?
 	return area == 0.0
 }

--- a/src/tools/wallmap/objloader.go
+++ b/src/tools/wallmap/objloader.go
@@ -5,41 +5,38 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"strconv"
 	"strings"
 )
 
-type Point2 struct {
-	X, Y float64
-}
+type Vertex [4]float64
 
-func (p *Point2) Scale(f float64) {
-	p.X = p.X * f
-	p.Y = p.Y * f
-}
-
-func Point2From3(p Point3) Point2 {
-	return Point2{p.X, p.Y}
-}
-
-type Point3 struct {
-	X, Y, Z float64
-}
-
-func (p *Point3) Set(s []string) error {
-	if _, err := fmt.Sscanf(s[0], "%f", &p.X); err != nil {
-		return fmt.Errorf("invalid syntax \"%s\"", s)
+func (v *Vertex) Scale(f float64) {
+	for i := range v {
+		v[i] *= f
 	}
-	if _, err := fmt.Sscanf(s[1], "%f", &p.Z); err != nil {
-		return fmt.Errorf("invalid syntax \"%s\"", s)
+}
+
+func (v *Vertex) Set(s []string) error {
+	var (
+		err error
+	)
+
+	for i := range s {
+		if v[i], err = strconv.ParseFloat(s[i], 64); err != nil {
+			return fmt.Errorf("invalid syntax \"%v\": %s", s[i], err)
+		}
 	}
-	if _, err := fmt.Sscanf(s[2], "%f", &p.Y); err != nil {
-		return fmt.Errorf("invalid syntax \"%s\"", s)
-	}
+
 	return nil
 }
 
+// Triangle represents a 3-sided polygon
+//
+// NOTE: this could easily be extended to support N-sided polygons
+// by using a []Vertex instead
 type Triangle struct {
-	P1, P2, P3 Point2
+	P1, P2, P3 Vertex
 }
 
 func (t *Triangle) Scale(f float64) {
@@ -72,7 +69,7 @@ func (t Triangle) isDegenerate() bool {
 }
 
 type ObjFile struct {
-	Vertices               []Point2
+	Vertices               []Vertex
 	Triangles              []Triangle
 	MinX, MinY, MaxX, MaxY float64
 	dbg                    bool
@@ -93,13 +90,13 @@ func SetMax(a *float64, b float64) {
 }
 
 func (of *ObjFile) parseVertex(lineno int, kw string, data []string) error {
-	p3 := Point3{}
-	err := p3.Set(data)
+	v := Vertex{}
+	err := v.Set(data)
 	if err != nil {
 		return err
 	}
 	// discard the Z coordinate
-	of.Vertices = append(of.Vertices, Point2From3(p3))
+	of.Vertices = append(of.Vertices, v)
 	return nil
 }
 

--- a/src/tools/wallmap/objloader.go
+++ b/src/tools/wallmap/objloader.go
@@ -174,7 +174,7 @@ func (of ObjFile) AABB() AABB {
 	return of.aabb
 }
 
-func (of *ObjFile) parseVertex(lineno int, kw string, data []string) error {
+func (of *ObjFile) parseVertex(kw string, data []string) error {
 	v := Vertex{}
 	err := v.Set(data)
 	if err != nil {
@@ -185,18 +185,17 @@ func (of *ObjFile) parseVertex(lineno int, kw string, data []string) error {
 	return nil
 }
 
-func (of *ObjFile) parseFace(lineno int, kw string, data []string) error {
+func (of *ObjFile) parseFace(kw string, data []string) error {
 	defer func() {
 		if r := recover(); r != nil {
 			fmt.Println("Error in parseFace", r)
-			fmt.Printf("lineno: %+v | kw: +%v | data : %+v\n", lineno, kw, data)
 			fmt.Println("len(of.vertices): ", len(of.vertices))
 			os.Exit(1)
 		}
 	}()
 
 	if len(data) != 3 {
-		return fmt.Errorf("line: %d, only triangular faces are supported", lineno)
+		return errors.New("only triangular faces are supported")
 	}
 
 	var (
@@ -256,14 +255,15 @@ func ReadObjFile(path string, dbg bool) (*ObjFile, error) {
 		kw, vals := line[0], line[1:]
 		switch kw {
 		case "v":
-			err := obj.parseVertex(lineno, kw, vals)
+			err := obj.parseVertex(kw, vals)
 			if err != nil {
-				return nil, fmt.Errorf("error parsing vertex: %v", err)
+				return nil, fmt.Errorf("error parsing vertex at line %d,\"%v\": %s", lineno, vals, err)
+
 			}
 		case "f":
-			err := obj.parseFace(lineno, kw, vals)
+			err := obj.parseFace(kw, vals)
 			if err != nil {
-				return nil, fmt.Errorf("error parsing face: %v", err)
+				return nil, fmt.Errorf("error parsing face at line %d,\"%v\": %s", lineno, vals, err)
 			}
 		default:
 			// ignore everything else

--- a/src/tools/wallmap/objloader_test.go
+++ b/src/tools/wallmap/objloader_test.go
@@ -1,0 +1,57 @@
+package main
+
+import "testing"
+
+func TestDegenerateTriangle(t *testing.T) {
+	var degTests = []struct {
+		x1, y1, z1 float64
+		x2, y2, z2 float64
+		x3, y3, z3 float64
+		expected   bool
+	}{
+		// 3 same points
+		{0, 0, 0, 0, 0, 0, 0, 0, 0, true},
+		{0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, true},
+		{0.353567426756, 0.353567426756, 0.353567426756, 0.353567426756, 0.353567426756, 0.353567426756, 0.353567426756, 0.353567426756, 0.353567426756, true},
+		{1, 1, 1, 1, 1, 1, 1, 1, 1, true},
+
+		// 2 same points
+		{1, 0, 0, 0, 0, 0, 0, 0, 0, true},
+		{0, 1, 0, 0, 0, 0, 0, 0, 0, true},
+		{0, 0, 1, 0, 0, 0, 0, 0, 0, true},
+		{0, 0, 0, 1, 0, 0, 0, 0, 0, true},
+		{0, 0, 0, 0, 1, 0, 0, 0, 0, true},
+		{0, 0, 0, 0, 0, 1, 0, 0, 0, true},
+		{0, 0, 0, 0, 0, 0, 1, 0, 0, true},
+		{0, 0, 0, 0, 0, 0, 0, 1, 0, true},
+		{0, 0, 0, 0, 0, 0, 0, 0, 1, true},
+
+		// 3 points on same line (axis //)
+		{1, 0, 0, 2, 0, 0, 3, 0, 0, true},
+		{0, 1, 0, 0, 2, 0, 0, 3, 0, true},
+
+		// 3 points on same line (random)
+		{0, 0, 0, 1, 2, 3, 2, 4, 6, true},
+		{-0.5, 1.5, 1, 1, 2, 3, 2.5, 2.5, 5, true},
+		{1 / 3, -1 / 6, 1 / 12, -1, 1 / 2, -2, -1 / 3, 1 / 6, -25/24 + 1/12, true},
+
+		// very small area
+		{1, 0, 0, 0, 1, 0, 0, 0, 0.000001, true},
+
+		// not degenerate
+		{1, 2, 3, -4, 5, 6, 7, 8, -9, false},
+		{1, 1, 2, 1, 2, 0, 2, 1, 0, false},
+	}
+
+	for _, tt := range degTests {
+		triangle := Triangle{
+			P1: NewVertex3D(tt.x1, tt.y1, tt.z1),
+			P2: NewVertex3D(tt.x2, tt.y2, tt.z2),
+			P3: NewVertex3D(tt.x3, tt.y3, tt.z3),
+		}
+		actual := triangle.isDegenerate()
+		if actual != tt.expected {
+			t.Errorf("Triangle.isDegenerate() (%v): expected %d, actual %d", triangle, tt.expected, actual)
+		}
+	}
+}

--- a/src/tools/wallmap/objloader_test.go
+++ b/src/tools/wallmap/objloader_test.go
@@ -51,7 +51,7 @@ func TestDegenerateTriangle(t *testing.T) {
 		}
 		actual := triangle.isDegenerate()
 		if actual != tt.expected {
-			t.Errorf("Triangle.isDegenerate() (%v): expected %d, actual %d", triangle, tt.expected, actual)
+			t.Errorf("Triangle.isDegenerate() (%v): expected %v, actual %v", triangle, tt.expected, actual)
 		}
 	}
 }

--- a/src/tools/wallmap/wallmap.go
+++ b/src/tools/wallmap/wallmap.go
@@ -68,7 +68,7 @@ func main() {
 	}
 
 	dc := gg.NewContext(w, h)
-	dc.SetRGB(1, 1, 1)
+	dc.SetRGB255(255, 255, 255)
 	dc.Clear()
 
 	for _, t := range obj.Triangles() {
@@ -80,7 +80,7 @@ func main() {
 		dc.LineTo(t.P2.X(), t.P2.Z())
 		dc.LineTo(t.P3.X(), t.P3.Z())
 		dc.LineTo(t.P1.X(), t.P1.Z())
-		dc.SetRGB(0, 0, 0)
+		dc.SetRGB255(0, 0, 0)
 		dc.SetLineWidth(1)
 		dc.FillPreserve()
 		dc.Stroke()

--- a/src/tools/wallmap/wallmap.go
+++ b/src/tools/wallmap/wallmap.go
@@ -44,8 +44,8 @@ func main() {
 	}
 
 	if *dbg {
-		fmt.Println("num triangles[0]: ", len(obj.Triangles()))
-		fmt.Println("triangles[0]: ", obj.Triangles()[0])
+		fmt.Println("num vertices: ", len(obj.Vertices()))
+		fmt.Println("num faces: ", len(obj.Triangles()))
 		fmt.Println("scale factor: ", *scale)
 	}
 
@@ -57,7 +57,7 @@ func main() {
 
 	negoff := offx < 0.0 || offy < 0.0
 	if negoff {
-		fmt.Printf("WARNING: the mesh 2D has negative offset(s), probably due to some negative coordinates: x:%d|y:%d\n", offx, offy)
+		fmt.Printf("WARNING: resulting 2D mesh has negative offset(s), probably due to some negative coordinates: x:%d|y:%d\n", offx, offy)
 	}
 
 	if *dbg || negoff {

--- a/src/tools/wallmap/wallmap.go
+++ b/src/tools/wallmap/wallmap.go
@@ -42,13 +42,13 @@ func main() {
 	}
 
 	if *dbg {
-		fmt.Println("num triangles[0]: ", len(obj.Triangles))
-		fmt.Println("triangles[0]: ", obj.Triangles[0])
+		fmt.Println("num triangles[0]: ", len(obj.Triangles()))
+		fmt.Println("triangles[0]: ", obj.Triangles()[0])
 		fmt.Println("scale factor: ", *scale)
 	}
 
 	// get image w/h by scaling the mesh aabb by the user-defined scale factor
-	aabb := obj.AABB
+	aabb := obj.AABB()
 	aabb.Scale(float64(*scale))
 	offx, offy := int(math.Floor(aabb.MinX)), int(math.Floor(aabb.MinZ))
 	w, h := int(math.Ceil(aabb.MaxX)), int(math.Ceil(aabb.MaxZ))
@@ -59,7 +59,7 @@ func main() {
 	}
 
 	if *dbg || negoff {
-		fmt.Println("mesh bounding box: ", obj.AABB)
+		fmt.Println("mesh bounding box: ", obj.AABB())
 		fmt.Println("scaled bounding box: ", aabb)
 		fmt.Println("image x, y offset: ", offx, offy)
 		fmt.Println("image width/height: ", w, h)
@@ -69,7 +69,7 @@ func main() {
 	dc.SetRGB(1, 1, 1)
 	dc.Clear()
 
-	for _, t := range obj.Triangles {
+	for _, t := range obj.Triangles() {
 		// scale current triangle
 		t.Scale(float64(*scale))
 

--- a/src/tools/wallmap/wallmap.go
+++ b/src/tools/wallmap/wallmap.go
@@ -45,18 +45,15 @@ func main() {
 		fmt.Println("num triangles[0]: ", len(obj.Triangles))
 		fmt.Println("triangles[0]: ", obj.Triangles[0])
 		fmt.Println("scale factor: ", *scale)
-		fmt.Println("org min: ", obj.MinX, obj.MinX)
-		fmt.Println("org max: ", obj.MaxX, obj.MaxY)
 	}
 
-	// image width, height
-	sMinX, sMaxX := float64(*scale)*obj.MinX, float64(*scale)*obj.MaxX
-	sMinY, sMaxY := float64(*scale)*obj.MinY, float64(*scale)*obj.MaxY
-	w, h := int(math.Ceil(sMaxX)), int(math.Ceil(sMaxY))
+	// get image w/h by scaling the mesh aabb by the user-defined scale factor
+	aabb := obj.AABB
+	aabb.Scale(float64(*scale))
+	offx, offy := int(math.Floor(aabb.MinX)), int(math.Floor(aabb.MinZ))
+	w, h := int(math.Ceil(aabb.MaxX)), int(math.Ceil(aabb.MaxZ))
 
 	if *dbg {
-		fmt.Println("scale min: ", sMinX, sMinY)
-		fmt.Println("scale max: ", sMaxX, sMaxY)
 		fmt.Println("image width/height: ", w, h)
 	}
 

--- a/src/tools/wallmap/wallmap.go
+++ b/src/tools/wallmap/wallmap.go
@@ -6,8 +6,10 @@ import (
 	"math"
 	"os"
 
+	"image/color"
+	"image/png"
+
 	"github.com/fogleman/gg"
-	"golang.org/x/image/bmp"
 )
 
 var (
@@ -84,16 +86,21 @@ func main() {
 		dc.Stroke()
 	}
 	fmt.Println("Rasterization completed")
-	fmt.Println("Creating", *bmpfile)
+	fmt.Println("Creating", *pngfile)
 
-	f, err := os.Create(*bmpfile)
+	f, err := os.Create(*pngfile)
 	if err != nil {
-		fmt.Println("Can't create ", *bmpfile, ": ", err)
+		fmt.Println("Can't create ", *pngfile, ": ", err)
 		os.Exit(1)
 	}
-	err = bmp.Encode(f, dc.Image())
+
+	// convert image into a black and white one
+	bw := []color.Color{color.Black, color.White}
+	gr := &Converter{dc.Image(), color.Palette(bw)}
+
+	err = png.Encode(f, gr)
 	if err != nil {
-		fmt.Println("Can't encode ", *bmpfile, ": ", err)
+		fmt.Println("Can't encode ", *pngfile, ": ", err)
 		os.Exit(1)
 	}
 }

--- a/src/tools/wallmap/wallmap.go
+++ b/src/tools/wallmap/wallmap.go
@@ -17,7 +17,7 @@ var (
 )
 
 func showUsage() {
-	fmt.Println("wallmap - Rasterize a 'walls-only 3D map' onto a bitmap")
+	fmt.Println("wallmap - Rasterize the triangular faces of an OBJ file onto a 2D image")
 	fmt.Println()
 	fmt.Println("usage:")
 	fmt.Println("  wallmap -div INT -bmp FILE OBJFILE")

--- a/src/tools/wallmap/wallmap.go
+++ b/src/tools/wallmap/wallmap.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"math"
+	"os"
+
+	"github.com/fogleman/gg"
+	"golang.org/x/image/bmp"
+)
+
+var (
+	scale   = flag.Int("scale", 1, "map mesh scale factor")
+	bmpfile = flag.String("bmp", "out.bmp", "output bmp file")
+	dbg     = flag.Bool("v", false, "verbose output")
+)
+
+func showUsage() {
+	fmt.Println("wallmap - Rasterize a 'walls-only 3D map' onto a bitmap")
+	fmt.Println()
+	fmt.Println("usage:")
+	fmt.Println("  wallmap -div INT -bmp FILE OBJFILE")
+	flag.PrintDefaults()
+}
+
+func main() {
+
+	objpath := ""
+	flag.Parse()
+	fmt.Println("nargs", flag.NArg())
+	if flag.NArg() > 0 {
+		objpath = flag.Arg(0)
+	} else {
+		showUsage()
+		os.Exit(0)
+	}
+
+	obj, err := ReadObjFile(objpath, *dbg)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	if *dbg {
+		fmt.Println("num triangles[0]: ", len(obj.Triangles))
+		fmt.Println("triangles[0]: ", obj.Triangles[0])
+		fmt.Println("scale factor: ", *scale)
+		fmt.Println("org min: ", obj.MinX, obj.MinX)
+		fmt.Println("org max: ", obj.MaxX, obj.MaxY)
+	}
+
+	// image width, height
+	sMinX, sMaxX := float64(*scale)*obj.MinX, float64(*scale)*obj.MaxX
+	sMinY, sMaxY := float64(*scale)*obj.MinY, float64(*scale)*obj.MaxY
+	w, h := int(math.Ceil(sMaxX)), int(math.Ceil(sMaxY))
+
+	if *dbg {
+		fmt.Println("scale min: ", sMinX, sMinY)
+		fmt.Println("scale max: ", sMaxX, sMaxY)
+		fmt.Println("image width/height: ", w, h)
+	}
+
+	dc := gg.NewContext(w, h)
+	dc.SetRGB(1, 1, 1)
+	dc.Clear()
+
+	for _, t := range obj.Triangles {
+		// scale current triangle
+		t.Scale(float64(*scale))
+
+		// draw the triangle
+		dc.MoveTo(t.P1.X, t.P1.Y)
+		dc.LineTo(t.P2.X, t.P2.Y)
+		dc.LineTo(t.P3.X, t.P3.Y)
+		dc.LineTo(t.P1.X, t.P1.Y)
+		dc.SetRGB(0, 0, 0)
+		dc.SetLineWidth(1)
+		dc.FillPreserve()
+		dc.Stroke()
+	}
+	fmt.Println("Rasterization completed")
+	fmt.Println("Creating", *bmpfile)
+
+	f, err := os.Create(*bmpfile)
+	if err != nil {
+		fmt.Println("Can't create ", *bmpfile, ": ", err)
+		os.Exit(1)
+	}
+	err = bmp.Encode(f, dc.Image())
+	if err != nil {
+		fmt.Println("Can't encode ", *bmpfile, ": ", err)
+		os.Exit(1)
+	}
+}

--- a/src/tools/wallmap/wallmap.go
+++ b/src/tools/wallmap/wallmap.go
@@ -53,7 +53,15 @@ func main() {
 	offx, offy := int(math.Floor(aabb.MinX)), int(math.Floor(aabb.MinZ))
 	w, h := int(math.Ceil(aabb.MaxX)), int(math.Ceil(aabb.MaxZ))
 
-	if *dbg {
+	negoff := offx < 0.0 || offy < 0.0
+	if negoff {
+		fmt.Printf("WARNING: the mesh 2D has negative offset(s), probably due to some negative coordinates: x:%d|y:%d\n", offx, offy)
+	}
+
+	if *dbg || negoff {
+		fmt.Println("mesh bounding box: ", obj.AABB)
+		fmt.Println("scaled bounding box: ", aabb)
+		fmt.Println("image x, y offset: ", offx, offy)
 		fmt.Println("image width/height: ", w, h)
 	}
 

--- a/src/tools/wallmap/wallmap.go
+++ b/src/tools/wallmap/wallmap.go
@@ -69,10 +69,10 @@ func main() {
 		t.Scale(float64(*scale))
 
 		// draw the triangle
-		dc.MoveTo(t.P1.X, t.P1.Y)
-		dc.LineTo(t.P2.X, t.P2.Y)
-		dc.LineTo(t.P3.X, t.P3.Y)
-		dc.LineTo(t.P1.X, t.P1.Y)
+		dc.MoveTo(t.P1.X(), t.P1.Y())
+		dc.LineTo(t.P2.X(), t.P2.Y())
+		dc.LineTo(t.P3.X(), t.P3.Y())
+		dc.LineTo(t.P1.X(), t.P1.Y())
 		dc.SetRGB(0, 0, 0)
 		dc.SetLineWidth(1)
 		dc.FillPreserve()

--- a/src/tools/wallmap/wallmap.go
+++ b/src/tools/wallmap/wallmap.go
@@ -14,15 +14,15 @@ import (
 
 var (
 	scale   = flag.Int("scale", 1, "map mesh scale factor")
-	bmpfile = flag.String("bmp", "out.bmp", "output bmp file")
+	pngfile = flag.String("png", "out.png", "output png file")
 	dbg     = flag.Bool("v", false, "verbose output")
 )
 
 func showUsage() {
-	fmt.Println("wallmap - Rasterize the triangular faces of an OBJ file onto a 2D image")
+	fmt.Println("wallmap - Rasterize the triangular faces of an OBJ file onto a PNG image")
 	fmt.Println()
 	fmt.Println("usage:")
-	fmt.Println("  wallmap -div INT -bmp FILE OBJFILE")
+	fmt.Println("  wallmap -div INT -png FILE OBJFILE")
 	flag.PrintDefaults()
 }
 

--- a/src/tools/wallmap/wallmap.go
+++ b/src/tools/wallmap/wallmap.go
@@ -28,7 +28,6 @@ func main() {
 
 	objpath := ""
 	flag.Parse()
-	fmt.Println("nargs", flag.NArg())
 	if flag.NArg() > 0 {
 		objpath = flag.Arg(0)
 	} else {

--- a/src/tools/wallmap/wallmap.go
+++ b/src/tools/wallmap/wallmap.go
@@ -69,10 +69,10 @@ func main() {
 		t.Scale(float64(*scale))
 
 		// draw the triangle
-		dc.MoveTo(t.P1.X(), t.P1.Y())
-		dc.LineTo(t.P2.X(), t.P2.Y())
-		dc.LineTo(t.P3.X(), t.P3.Y())
-		dc.LineTo(t.P1.X(), t.P1.Y())
+		dc.MoveTo(t.P1.X(), t.P1.Z())
+		dc.LineTo(t.P2.X(), t.P2.Z())
+		dc.LineTo(t.P3.X(), t.P3.Z())
+		dc.LineTo(t.P1.X(), t.P1.Z())
 		dc.SetRGB(0, 0, 0)
 		dc.SetLineWidth(1)
 		dc.FillPreserve()


### PR DESCRIPTION
Add `wallmap` source, go executable to rasterize the walls `.obj` file into a bitmap.
- `objloader.go`: super basic obj GO file loader, that spits triangles
- `wallmap.go`: cli executable, takes a `-scale` param and generates the bitmap.

Image size and origin offset:
- If `maxx`, `maxy` are the highest `x` and `y` values of the mesh vertices, then the resulting bitmap will have a width of `scale * maxx` and a height of `scale * maxy`.  
- by convention, pixel coordinates of the 2D bitmap **do not need to be translated** in order to be converted to _Game Units_, in other words the point `0,0` of the world **IS** the origin of the bitmap. The only transformation needed to pass from _Game Coord_ to _Bitmap Coord_ is a scaling, the one that was defined when running `wallmap`. That is why there should not be any negative `X` or `Y` coordinates in the terrain OBJ file as they would imply an additional translation. The tool should refuse to generate the bitmap **in case of negative coordinates**, or at the very least emit a warning.

**NOTE:** source code is added to `ROOT/src/tools/` because it has to be in the `$GOPATH`
Maybe `ROOT/src/tool` could become the new tool destination, for this reason.

**TODO**:
- Add a README with an example of use
