### PR TITLE
Use latest `datalib` revision

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -79,7 +79,7 @@ TARGETS = [
     {
         'name': 'renderlib',
         'url': 'git@github.com:RookieGameDevs/renderlib.git',
-        'ref': 'b4b8eb77158d8785260663448d2ccc46531d5ba9',
+        'ref': 'ff9d966f55fbf1a70bfd1ede31ca84eba41605bd',
         'build': build_renderlib,
     },
 ]

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -67,7 +67,7 @@ TARGETS = [
     {
         'name': 'datalib',
         'url': 'git@github.com:RookieGameDevs/datalib.git',
-        'ref': 'b7ad087aef26e5d3dda3d6021e03ba1d43a8871d',
+        'ref': '4c5e707a2a0e4f34d9632f37f0e37614c4fdb36f',
         'build': build_datalib,
     },
     {


### PR DESCRIPTION
By default, `datalib` won't build tests, which in turn, doesn't require `check` library to be installed.